### PR TITLE
Add style calc helper and minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Util.style.toTransformString({ rotate: 90 });
 Or be more selective:
 
 ```javascript
-import { warn } from "victory-util/log";
-import { containsStrings, containsOnlyStrings } from "victory-util/collection";
+import { warn } from "victory-util/lib/log";
+import { containsStrings, containsOnlyStrings } from "victory-util/lib/collection";
 ```
 
 ## Development

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "css-loader": "^0.20.1",
     "file-loader": "^0.8.4",
     "lodash": "^3.10.1",
+    "reduce-css-calc": "^1.2.0",
     "rimraf": "^2.4.0",
     "style-loader": "^0.12.4",
     "url-loader": "~0.5.5",

--- a/src/style.js
+++ b/src/style.js
@@ -1,3 +1,5 @@
+import reduceCSSCalc from "reduce-css-calc";
+
 /**
  * Given an object with CSS/SVG transform definitions, return the string value
  * for use with the `transform` CSS property or SVG attribute. Note that we
@@ -8,6 +10,9 @@
  * @returns {String} The generated transform string.
  */
 export const toTransformString = function (obj) {
+  if (!obj || typeof obj === "string") {
+    return obj;
+  }
   const transforms = [];
   for (const key in obj) {
     if (obj.hasOwnProperty(key)) {
@@ -17,3 +22,7 @@ export const toTransformString = function (obj) {
   }
   return transforms.join(" ");
 };
+
+export const calc = function (expr, precision) {
+  return reduceCSSCalc(`calc(${expr})`, precision);
+}

--- a/src/style.js
+++ b/src/style.js
@@ -25,4 +25,4 @@ export const toTransformString = function (obj) {
 
 export const calc = function (expr, precision) {
   return reduceCSSCalc(`calc(${expr})`, precision);
-}
+};


### PR DESCRIPTION
`calc` is a thin wrapper around the `reduce-css-calc`, so we can change the implementation if necessary. (You also don't need to write the `calc(...)` part everywhere.)

Needed for `victory-label` initial release.

/cc @boygirl 
