### PR TITLE
Add cumulative max and min methods

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -14,17 +14,25 @@ export const containsOnlyStrings = function (collection) {
 
 
 export const getCumulativeMax = function (datasets, dependentAxis) {
-  return _.reduce(datasets, (memo, dataset) => {
+  const barHeights = [];
+  _.forEach(datasets, (dataset) => {
     dataset = dataset.data || dataset;
-    const localMax = (_.max(_.pluck(dataset, dependentAxis)));
-    return localMax > 0 ? memo + localMax : memo;
-  }, 0);
+    barHeights.push(_.reduce(dataset, (memo, datum) => {
+      const height = datum[dependentAxis];
+      return height > 0 ? memo + height : memo;
+    }, 0));
+  });
+  return _.max(barHeights);
 };
 
 export const getCumulativeMin = function (datasets, dependentAxis) {
-  return _.reduce(datasets, (memo, dataset) => {
+  const barHeights = [];
+  _.forEach(datasets, (dataset) => {
     dataset = dataset.data || dataset;
-    const localMin = (_.min(_.pluck(dataset, dependentAxis)));
-    return localMin < 0 ? memo + localMin : memo;
-  }, 0);
+    barHeights.push(_.reduce(dataset, (memo, datum) => {
+      const height = datum[dependentAxis];
+      return height < 0 ? memo + height : memo;
+    }, 0));
+  });
+  return _.min(barHeights);
 };

--- a/src/collection.js
+++ b/src/collection.js
@@ -11,3 +11,19 @@ export const containsOnlyStrings = function (collection) {
     return _.isString(item);
   });
 };
+
+export const getCumulativeMax = function (datasets, dependentAxis) {
+  return _.reduce(datasets, (memo, dataset) => {
+    dataset = dataset.data || dataset;
+    const localMax = (_.max(_.pluck(dataset, dependentAxis)));
+    return localMax > 0 ? memo + localMax : memo;
+  }, 0);
+};
+
+export const getCumulativeMin = function (datasets, dependentAxis) {
+  return _.reduce(datasets, (memo, dataset) => {
+    dataset = dataset.data || dataset;
+    const localMin = (_.min(_.pluck(dataset, dependentAxis)));
+    return localMin < 0 ? memo + localMin : memo;
+  }, 0);
+};

--- a/src/collection.js
+++ b/src/collection.js
@@ -12,6 +12,7 @@ export const containsOnlyStrings = function (collection) {
   });
 };
 
+
 export const getCumulativeMax = function (datasets, dependentAxis) {
   return _.reduce(datasets, (memo, dataset) => {
     dataset = dataset.data || dataset;


### PR DESCRIPTION
For use in VictoryBar and VictoryChart; they accumulate the max and min of each dataset and returns the largest/smallest out of the accumulation.

cc/ @boygirl 
