### PR TITLE
Add PropTypes module, update top-level module names

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Access all utils at once:
 ```javascript
 import Util from "victory-util";
 
-Util.log.warn("Uh oh!");
-Util.style.toTransformString({ rotate: 90 });
+Util.Log.warn("Uh oh!");
+Util.Style.toTransformString({ rotate: 90 });
 ```
 
 Or be more selective:
@@ -23,6 +23,7 @@ Or be more selective:
 ```javascript
 import { warn } from "victory-util/lib/log";
 import { containsStrings, containsOnlyStrings } from "victory-util/lib/collection";
+import * as VictoryPropTypes from "victory-util/lib/prop-types";
 ```
 
 ## Development

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,13 @@
-import * as collection from "./collection";
-import * as log from "./log";
-import * as style from "./style";
+import * as Collection from "./collection";
+import * as Log from "./log";
+import * as Style from "./style";
+import * as Type from "./type";
+import * as PropTypes from "./prop-types";
 
 export default {
-  collection,
-  log,
-  style
+  Collection,
+  Log,
+  Style,
+  Type,
+  PropTypes
 };

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -1,0 +1,99 @@
+import { PropTypes } from "react";
+import { getConstructor, getConstructorName } from "./type";
+import _ from "lodash";
+
+/**
+ * Return a new validator based on `validator` but with the option to chain
+ * `isRequired` onto the validation. This is nearly identical to how React
+ * does it internally, but they don't expose their helper for us to use.
+ * @param {Function} validator Validation function.
+ * @returns {Function} Validator with `isRequired` option.
+ */
+export const makeChainable = function (validator) {
+  /* eslint-disable max-params */
+  const _chainable = function (isRequired, props, propName, componentName) {
+    const value = props[propName];
+    if (typeof value === "undefined" || value === null) {
+      if (isRequired) {
+        return new Error(
+          `Required \`${propName}\` was not specified in \`${componentName}\`.`
+        );
+      }
+      return null;
+    }
+    return validator(props, propName, componentName);
+  };
+  const chainable = _.bind(_chainable, null, false);
+  chainable.isRequired = _.bind(_chainable, null, true);
+  return chainable;
+};
+
+/**
+ * Check that the value is a non-negative number.
+ */
+export const nonNegative = makeChainable((props, propName, componentName) => {
+  const error = PropTypes.number(props, propName, componentName);
+  if (error) {
+    return error;
+  }
+  const value = props[propName];
+  if (value < 0) {
+    return new Error(
+      `\`${propName}\` in \`${componentName}\` must be non-negative.`
+    );
+  }
+});
+
+/**
+ * Check that the value is a two-item Array in ascending order.
+ */
+export const minMaxArray = makeChainable((props, propName, componentName) => {
+  const error = PropTypes.array(props, propName, componentName);
+  if (error) {
+    return error;
+  }
+  const value = props[propName];
+  if (value.length !== 2 || value[1] < value[0]) {
+    return new Error(
+      `\`${propName}\` in \`${componentName}\` must be a [min, max] array.`
+    );
+  }
+});
+
+/**
+ * Check that the value looks like a d3 `scale` function.
+ */
+export const scale = makeChainable((props, propName, componentName) => {
+  const value = props[propName];
+  if (typeof value !== "function" || !value.copy || !value.domain || !value.range) {
+    return new Error(
+      `\`${propName}\` in \`${componentName}\` must be a d3 scale.`
+    );
+  }
+});
+
+/**
+ * Check that an array contains items of the same type.
+ */
+export const homogenousArray = makeChainable((props, propName, componentName) => {
+  const error = PropTypes.array(props, propName, componentName);
+  if (error) {
+    return error;
+  }
+  const value = props[propName];
+  if (value.length > 1) {
+    const constructor = getConstructor(value[0]);
+    for (let i = 1; i < value.length; i++) {
+      const otherConstructor = getConstructor(value[i]);
+      if (constructor !== otherConstructor) {
+        const constructorName = getConstructorName(value[0]);
+        const otherConstructorName = getConstructorName(value[i]);
+        return new Error(
+          `Expected \`${propName}\` in \`${componentName}\` to be a ` +
+          `homogenous array, but found types \`${constructorName}\` and ` +
+          `\`${otherConstructorName}\`.`
+        );
+      }
+    }
+  }
+});

--- a/src/type.js
+++ b/src/type.js
@@ -1,0 +1,33 @@
+export const nullConstructor = function () { return null; };
+export const undefinedConstructor = function () { return; };
+/**
+ * Get the constructor of `value`. If `value` is null or undefined, return the
+ * special singletons `nullConstructor` or `undefinedConstructor`, respectively.
+ * @param {*} value Instance to return the constructor of.
+ * @returns {Function} Constructor of `value`.
+ */
+export const getConstructor = function (value) {
+  if (typeof value === "undefined") {
+    return undefinedConstructor;
+  } else if (value === null) {
+    return nullConstructor;
+  } else {
+    return value.constructor;
+  }
+};
+
+/**
+ * Get the name of the constructor used to create `value`, using
+ * `Object.protoype.toString`. If the value is null or undefined, return
+ * "null" or "undefined", respectively.
+ * @param {*} value Instance to return the constructor name of.
+ * @returns {String} Name of the constructor.
+ */
+export const getConstructorName = function (value) {
+  if (typeof value === "undefined") {
+    return "undefined";
+  } else if (value === null) {
+    return "null";
+  }
+  return Object.prototype.toString.call(value).slice(8, -1);
+};


### PR DESCRIPTION
This updates module names to be uppercase, to align with React. For example, `Util.log.warn` is now `Util.Log.warn`. Looks a lot better when you're importing entire modules. This change requires a semver-MAJOR bump.

A new `PropTypes` module is added, with several validators that will be interesting to Victory components:

``` jsx
import * as VictoryPropTypes from "victory-util/lib/prop-types";
// or `import Util from "victory-util"` then use `Util.PropTypes`...

class MyComponent extends React.Component {
  static propTypes = {
    // Must be a two-item ascending array.
    domain: VictoryPropTypes.minMaxArray,
    // Must look vaguely like a d3 `scale` function.
    scale: VictoryPropTypes.scale,
    // Items can be any type, as long as they're all the *same* type.
    tickValues: VictoryPropTypes.homogenousArray,
    // Like `number`, but can't be < 0.
    width: VictoryPropTypes.nonNegative,
    height: VictoryPropTypes.nonNegative
  };
}
```

/cc @boygirl
