### PR TITLE
Add tests for collection methods

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -7,9 +7,7 @@ export const containsStrings = function (collection) {
 };
 
 export const containsOnlyStrings = function (collection) {
-  return _.every(collection, (item) => {
-    return _.isString(item);
-  });
+  return _.isArray(collection) && _.every(collection, _.isString);
 };
 
 export const isArrayOfArrays = function (collection) {

--- a/src/collection.js
+++ b/src/collection.js
@@ -1,15 +1,19 @@
 import _ from "lodash";
 
+export const isNonEmptyArray = function (collection) {
+  return _.isArray(collection) && collection.length > 0;
+};
+
 export const containsStrings = function (collection) {
   return _.some(collection, _.isString);
 };
 
 export const containsOnlyStrings = function (collection) {
-  return _.isArray(collection) && _.every(collection, _.isString);
+  return isNonEmptyArray(collection) && _.every(collection, _.isString);
 };
 
 export const isArrayOfArrays = function (collection) {
-  return _.isArray(collection) && _.every(collection, _.isArray);
+  return isNonEmptyArray(collection) && _.every(collection, _.isArray);
 };
 
 export const removeUndefined = function (arr) {

--- a/src/collection.js
+++ b/src/collection.js
@@ -1,9 +1,7 @@
 import _ from "lodash";
 
 export const containsStrings = function (collection) {
-  return _.some(collection, (item) => {
-    return _.isString(item);
-  });
+  return _.some(collection, _.isString);
 };
 
 export const containsOnlyStrings = function (collection) {
@@ -11,9 +9,7 @@ export const containsOnlyStrings = function (collection) {
 };
 
 export const isArrayOfArrays = function (collection) {
-  return _.isArray(collection) && _.every(collection, (item) => {
-    return _.isArray(item);
-  });
+  return _.isArray(collection) && _.every(collection, _.isArray);
 };
 
 export const removeUndefined = function (arr) {

--- a/test/client/spec/collection.spec.js
+++ b/test/client/spec/collection.spec.js
@@ -1,7 +1,8 @@
 import {
   containsStrings,
   containsOnlyStrings,
-  isArrayOfArrays
+  isArrayOfArrays,
+  removeUndefined
 } from "src/collection";
 
 describe("containsStrings", () => {
@@ -79,5 +80,22 @@ describe("isArrayOfArrays", () => {
     expect(isArrayOfArrays([ [{}] ])).to.equal(true);
     expect(isArrayOfArrays([ [ [] ] ])).to.equal(true);
     expect(isArrayOfArrays([ [], [] ])).to.equal(true);
+  });
+});
+
+describe("removeUndefined", () => {
+  it("handles empty array", () => {
+    expect(removeUndefined([])).to.eql([]);
+  });
+
+  it("does not filter non-undefineds", () => {
+    const testArray = [0, 1, 'a', {}, false, null, NaN];
+    expect(removeUndefined(testArray)).to.eql(testArray);
+  });
+
+  it("filters out undefineds", () => {
+    const testArray = [undefined, 0, undefined, {}, false, null, NaN, undefined];
+    const expectedArray = [0, {}, false, null, NaN];
+    expect(removeUndefined(testArray)).to.eql(expectedArray);
   });
 });

--- a/test/client/spec/collection.spec.js
+++ b/test/client/spec/collection.spec.js
@@ -1,0 +1,30 @@
+import { isArrayOfArrays } from "src/collection";
+
+describe("isArrayOfArrays", () => {
+  it("handles empty argument", () => {
+    expect(isArrayOfArrays()).to.equal(false);
+  });
+
+  it("handles empty array", () => {
+    expect(isArrayOfArrays([])).to.equal(false);
+  });
+
+  it("returns false for collections of non-arrays", () => {
+    expect(isArrayOfArrays([1])).to.equal(false);
+    expect(isArrayOfArrays([{}])).to.equal(false);
+    expect(isArrayOfArrays(['a'])).to.equal(false);
+  });
+
+  it("returns false for mixed collections", () => {
+    expect(isArrayOfArrays([[], 1, {}])).to.equal(false);
+    expect(isArrayOfArrays([1, [], {}])).to.equal(false);
+    expect(isArrayOfArrays([1, {}, []])).to.equal(false);
+  });
+
+  it("returns true for collections of arrays", () => {
+    expect(isArrayOfArrays([ [] ])).to.equal(true);
+    expect(isArrayOfArrays([ [{}] ])).to.equal(true);
+    expect(isArrayOfArrays([ [ [] ] ])).to.equal(true);
+    expect(isArrayOfArrays([ [], [] ])).to.equal(true);
+  });
+});

--- a/test/client/spec/collection.spec.js
+++ b/test/client/spec/collection.spec.js
@@ -17,13 +17,13 @@ describe("containsStrings", () => {
   it("returns false for collections of non-strings", () => {
     expect(containsStrings([0, 1])).to.equal(false);
     expect(containsStrings([undefined, null, NaN])).to.equal(false);
-    expect(containsStrings([{}, {a: 'foo'}])).to.equal(false);
+    expect(containsStrings([{}, {a: "foo"}])).to.equal(false);
   });
 
   it("returns false for collections with strings", () => {
-    expect(containsStrings(['hello'])).to.equal(true);
-    expect(containsStrings(['hello', 'there'])).to.equal(true);
-    expect(containsStrings([0, 'hello', {}, null])).to.equal(true);
+    expect(containsStrings(["hello"])).to.equal(true);
+    expect(containsStrings(["hello", "there"])).to.equal(true);
+    expect(containsStrings([0, "hello", {}, null])).to.equal(true);
   });
 });
 
@@ -39,18 +39,18 @@ describe("containsOnlyStrings", () => {
   it("returns false for collections of non-strings", () => {
     expect(containsOnlyStrings([0, 1])).to.equal(false);
     expect(containsOnlyStrings([undefined, null, NaN])).to.equal(false);
-    expect(containsOnlyStrings([{}, {a: 'foo'}])).to.equal(false);
+    expect(containsOnlyStrings([{}, {a: "foo"}])).to.equal(false);
   });
 
   it("returns false for collections with some strings", () => {
-    expect(containsOnlyStrings(['hello', 0])).to.equal(false);
-    expect(containsOnlyStrings(['hello', ['not me']])).to.equal(false);
-    expect(containsOnlyStrings([0, 'hello', {}, null])).to.equal(false);
+    expect(containsOnlyStrings(["hello", 0])).to.equal(false);
+    expect(containsOnlyStrings(["hello", ["not me"]])).to.equal(false);
+    expect(containsOnlyStrings([0, "hello", {}, null])).to.equal(false);
   });
 
   it("returns true for collections with only strings", () => {
-    expect(containsOnlyStrings(['hello'])).to.equal(true);
-    expect(containsOnlyStrings(['hello', 'there'])).to.equal(true);
+    expect(containsOnlyStrings(["hello"])).to.equal(true);
+    expect(containsOnlyStrings(["hello", "there"])).to.equal(true);
   });
 });
 
@@ -66,7 +66,7 @@ describe("isArrayOfArrays", () => {
   it("returns false for collections of non-arrays", () => {
     expect(isArrayOfArrays([1])).to.equal(false);
     expect(isArrayOfArrays([{}])).to.equal(false);
-    expect(isArrayOfArrays(['a'])).to.equal(false);
+    expect(isArrayOfArrays(["a"])).to.equal(false);
   });
 
   it("returns false for mixed collections", () => {
@@ -89,7 +89,7 @@ describe("removeUndefined", () => {
   });
 
   it("does not filter non-undefineds", () => {
-    const testArray = [0, 1, 'a', {}, false, null, NaN];
+    const testArray = [0, 1, "a", {}, false, null, NaN];
     expect(removeUndefined(testArray)).to.eql(testArray);
   });
 

--- a/test/client/spec/collection.spec.js
+++ b/test/client/spec/collection.spec.js
@@ -1,4 +1,29 @@
-import { isArrayOfArrays } from "src/collection";
+import {
+  containsStrings,
+  isArrayOfArrays
+} from "src/collection";
+
+describe("containsStrings", () => {
+  it("handles empty argument", () => {
+    expect(containsStrings()).to.equal(false);
+  });
+
+  it("handles empty array", () => {
+    expect(containsStrings([])).to.equal(false);
+  });
+
+  it("returns false for collections of non-strings", () => {
+    expect(containsStrings([0, 1])).to.equal(false);
+    expect(containsStrings([undefined, null, NaN])).to.equal(false);
+    expect(containsStrings([{}, {a: 'foo'}])).to.equal(false);
+  });
+
+  it("returns false for collections with strings", () => {
+    expect(containsStrings(['hello'])).to.equal(true);
+    expect(containsStrings(['hello', 'there'])).to.equal(true);
+    expect(containsStrings([0, 'hello', {}, null])).to.equal(true);
+  });
+});
 
 describe("isArrayOfArrays", () => {
   it("handles empty argument", () => {

--- a/test/client/spec/collection.spec.js
+++ b/test/client/spec/collection.spec.js
@@ -1,5 +1,6 @@
 import {
   containsStrings,
+  containsOnlyStrings,
   isArrayOfArrays
 } from "src/collection";
 
@@ -22,6 +23,33 @@ describe("containsStrings", () => {
     expect(containsStrings(['hello'])).to.equal(true);
     expect(containsStrings(['hello', 'there'])).to.equal(true);
     expect(containsStrings([0, 'hello', {}, null])).to.equal(true);
+  });
+});
+
+describe("containsOnlyStrings", () => {
+  it("handles empty argument", () => {
+    expect(containsOnlyStrings()).to.equal(false);
+  });
+
+  it("handles empty array", () => {
+    expect(containsOnlyStrings([])).to.equal(false);
+  });
+
+  it("returns false for collections of non-strings", () => {
+    expect(containsOnlyStrings([0, 1])).to.equal(false);
+    expect(containsOnlyStrings([undefined, null, NaN])).to.equal(false);
+    expect(containsOnlyStrings([{}, {a: 'foo'}])).to.equal(false);
+  });
+
+  it("returns false for collections with some strings", () => {
+    expect(containsOnlyStrings(['hello', 0])).to.equal(false);
+    expect(containsOnlyStrings(['hello', ['not me']])).to.equal(false);
+    expect(containsOnlyStrings([0, 'hello', {}, null])).to.equal(false);
+  });
+
+  it("returns true for collections with only strings", () => {
+    expect(containsOnlyStrings(['hello'])).to.equal(true);
+    expect(containsOnlyStrings(['hello', 'there'])).to.equal(true);
   });
 });
 

--- a/test/client/spec/collection.spec.js
+++ b/test/client/spec/collection.spec.js
@@ -1,101 +1,124 @@
 import {
+  isNonEmptyArray,
   containsStrings,
   containsOnlyStrings,
   isArrayOfArrays,
   removeUndefined
 } from "src/collection";
 
-describe("containsStrings", () => {
-  it("handles empty argument", () => {
-    expect(containsStrings()).to.equal(false);
+describe("collections", () => {
+
+  describe("isNonEmptyArray", () => {
+
+    it("returns false for undefined argument", () => {
+      expect(isNonEmptyArray()).to.equal(false);
+    });
+
+    it("returns false for empty array", () => {
+      expect(isNonEmptyArray([])).to.equal(false);
+    });
+
+    it("returns true for non-empty array", () => {
+      expect(isNonEmptyArray(["hello"])).to.equal(true);
+    });
   });
 
-  it("handles empty array", () => {
-    expect(containsStrings([])).to.equal(false);
+  describe("containsStrings", () => {
+
+    it("handles empty argument", () => {
+      expect(containsStrings()).to.equal(false);
+    });
+
+    it("handles empty array", () => {
+      expect(containsStrings([])).to.equal(false);
+    });
+
+    it("returns false for collections of non-strings", () => {
+      expect(containsStrings([0, 1])).to.equal(false);
+      expect(containsStrings([undefined, null, NaN])).to.equal(false);
+      expect(containsStrings([{}, {a: "foo"}])).to.equal(false);
+    });
+
+    it("returns false for collections with strings", () => {
+      expect(containsStrings(["hello"])).to.equal(true);
+      expect(containsStrings(["hello", "there"])).to.equal(true);
+      expect(containsStrings([0, "hello", {}, null])).to.equal(true);
+    });
   });
 
-  it("returns false for collections of non-strings", () => {
-    expect(containsStrings([0, 1])).to.equal(false);
-    expect(containsStrings([undefined, null, NaN])).to.equal(false);
-    expect(containsStrings([{}, {a: "foo"}])).to.equal(false);
+  describe("containsOnlyStrings", () => {
+
+    it("handles empty argument", () => {
+      expect(containsOnlyStrings()).to.equal(false);
+    });
+
+    it("handles empty array", () => {
+      expect(containsOnlyStrings([])).to.equal(false);
+    });
+
+    it("returns false for collections of non-strings", () => {
+      expect(containsOnlyStrings([0, 1])).to.equal(false);
+      expect(containsOnlyStrings([undefined, null, NaN])).to.equal(false);
+      expect(containsOnlyStrings([{}, {a: "foo"}])).to.equal(false);
+    });
+
+    it("returns false for collections with some strings", () => {
+      expect(containsOnlyStrings(["hello", 0])).to.equal(false);
+      expect(containsOnlyStrings(["hello", ["not me"]])).to.equal(false);
+      expect(containsOnlyStrings([0, "hello", {}, null])).to.equal(false);
+    });
+
+    it("returns true for collections with only strings", () => {
+      expect(containsOnlyStrings(["hello"])).to.equal(true);
+      expect(containsOnlyStrings(["hello", "there"])).to.equal(true);
+    });
   });
 
-  it("returns false for collections with strings", () => {
-    expect(containsStrings(["hello"])).to.equal(true);
-    expect(containsStrings(["hello", "there"])).to.equal(true);
-    expect(containsStrings([0, "hello", {}, null])).to.equal(true);
-  });
-});
+  describe("isArrayOfArrays", () => {
 
-describe("containsOnlyStrings", () => {
-  it("handles empty argument", () => {
-    expect(containsOnlyStrings()).to.equal(false);
-  });
+    it("handles empty argument", () => {
+      expect(isArrayOfArrays()).to.equal(false);
+    });
 
-  it("handles empty array", () => {
-    expect(containsOnlyStrings([])).to.equal(false);
-  });
+    it("handles empty array", () => {
+      expect(isArrayOfArrays([])).to.equal(false);
+    });
 
-  it("returns false for collections of non-strings", () => {
-    expect(containsOnlyStrings([0, 1])).to.equal(false);
-    expect(containsOnlyStrings([undefined, null, NaN])).to.equal(false);
-    expect(containsOnlyStrings([{}, {a: "foo"}])).to.equal(false);
-  });
+    it("returns false for collections of non-arrays", () => {
+      expect(isArrayOfArrays([1])).to.equal(false);
+      expect(isArrayOfArrays([{}])).to.equal(false);
+      expect(isArrayOfArrays(["a"])).to.equal(false);
+    });
 
-  it("returns false for collections with some strings", () => {
-    expect(containsOnlyStrings(["hello", 0])).to.equal(false);
-    expect(containsOnlyStrings(["hello", ["not me"]])).to.equal(false);
-    expect(containsOnlyStrings([0, "hello", {}, null])).to.equal(false);
-  });
+    it("returns false for mixed collections", () => {
+      expect(isArrayOfArrays([[], 1, {}])).to.equal(false);
+      expect(isArrayOfArrays([1, [], {}])).to.equal(false);
+      expect(isArrayOfArrays([1, {}, []])).to.equal(false);
+    });
 
-  it("returns true for collections with only strings", () => {
-    expect(containsOnlyStrings(["hello"])).to.equal(true);
-    expect(containsOnlyStrings(["hello", "there"])).to.equal(true);
-  });
-});
-
-describe("isArrayOfArrays", () => {
-  it("handles empty argument", () => {
-    expect(isArrayOfArrays()).to.equal(false);
+    it("returns true for collections of arrays", () => {
+      expect(isArrayOfArrays([ [] ])).to.equal(true);
+      expect(isArrayOfArrays([ [{}] ])).to.equal(true);
+      expect(isArrayOfArrays([ [ [] ] ])).to.equal(true);
+      expect(isArrayOfArrays([ [], [] ])).to.equal(true);
+    });
   });
 
-  it("handles empty array", () => {
-    expect(isArrayOfArrays([])).to.equal(false);
-  });
+  describe("removeUndefined", () => {
 
-  it("returns false for collections of non-arrays", () => {
-    expect(isArrayOfArrays([1])).to.equal(false);
-    expect(isArrayOfArrays([{}])).to.equal(false);
-    expect(isArrayOfArrays(["a"])).to.equal(false);
-  });
+    it("handles empty array", () => {
+      expect(removeUndefined([])).to.eql([]);
+    });
 
-  it("returns false for mixed collections", () => {
-    expect(isArrayOfArrays([[], 1, {}])).to.equal(false);
-    expect(isArrayOfArrays([1, [], {}])).to.equal(false);
-    expect(isArrayOfArrays([1, {}, []])).to.equal(false);
-  });
+    it("does not filter non-undefineds", () => {
+      const testArray = [0, 1, "a", {}, false, null, NaN];
+      expect(removeUndefined(testArray)).to.eql(testArray);
+    });
 
-  it("returns true for collections of arrays", () => {
-    expect(isArrayOfArrays([ [] ])).to.equal(true);
-    expect(isArrayOfArrays([ [{}] ])).to.equal(true);
-    expect(isArrayOfArrays([ [ [] ] ])).to.equal(true);
-    expect(isArrayOfArrays([ [], [] ])).to.equal(true);
-  });
-});
-
-describe("removeUndefined", () => {
-  it("handles empty array", () => {
-    expect(removeUndefined([])).to.eql([]);
-  });
-
-  it("does not filter non-undefineds", () => {
-    const testArray = [0, 1, "a", {}, false, null, NaN];
-    expect(removeUndefined(testArray)).to.eql(testArray);
-  });
-
-  it("filters out undefineds", () => {
-    const testArray = [undefined, 0, undefined, {}, false, null, NaN, undefined];
-    const expectedArray = [0, {}, false, null, NaN];
-    expect(removeUndefined(testArray)).to.eql(expectedArray);
+    it("filters out undefineds", () => {
+      const testArray = [undefined, 0, undefined, {}, false, null, NaN, undefined];
+      const expectedArray = [0, {}, false, null, NaN];
+      expect(removeUndefined(testArray)).to.eql(expectedArray);
+    });
   });
 });


### PR DESCRIPTION
- [x] Add tests for isArrayOfArrays
- [x] Add tests for containsStrings
- [x] Add tests for containsOnlyStrings
- [x] Add tests for removeUndefined

Changed behavior – `containsOnlyStrings` and `isArrayOfArrays` now returns false with input `[]`:
Don't merge until https://github.com/FormidableLabs/victory-util/issues/12 has been answered.

/cc @boygirl 
