### PR TITLE
change minMaxArray prop to domain, correct spelling, tests

### DIFF
--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -45,17 +45,17 @@ export const nonNegative = makeChainable((props, propName, componentName) => {
 });
 
 /**
- * Check that the value is a two-item Array in ascending order.
+ * Check that the value is an Array of two unique values.
  */
-export const minMaxArray = makeChainable((props, propName, componentName) => {
+export const domain = makeChainable((props, propName, componentName) => {
   const error = PropTypes.array(props, propName, componentName);
   if (error) {
     return error;
   }
   const value = props[propName];
-  if (value.length !== 2 || value[1] < value[0]) {
+  if (value.length !== 2 || value[1] === value[0]) {
     return new Error(
-      `\`${propName}\` in \`${componentName}\` must be a [min, max] array.`
+      `\`${propName}\` in \`${componentName}\` must be an array of two unique numeric values.`
     );
   }
 });
@@ -75,7 +75,7 @@ export const scale = makeChainable((props, propName, componentName) => {
 /**
  * Check that an array contains items of the same type.
  */
-export const homogenousArray = makeChainable((props, propName, componentName) => {
+export const homogeneousArray = makeChainable((props, propName, componentName) => {
   const error = PropTypes.array(props, propName, componentName);
   if (error) {
     return error;
@@ -90,7 +90,7 @@ export const homogenousArray = makeChainable((props, propName, componentName) =>
         const otherConstructorName = getConstructorName(value[i]);
         return new Error(
           `Expected \`${propName}\` in \`${componentName}\` to be a ` +
-          `homogenous array, but found types \`${constructorName}\` and ` +
+          `homogeneous array, but found types \`${constructorName}\` and ` +
           `\`${otherConstructorName}\`.`
         );
       }

--- a/test/client/main.js
+++ b/test/client/main.js
@@ -29,11 +29,11 @@ window.mocha.setup({
 // --------------------------------------------------------------------------
 // Use webpack to include all app code _except_ the entry point so we can get
 // code coverage in the bundle, whether tested or not.
-const srcReq = require.context("src", true, /\.jsx?$/);
+const srcReq = require.context("src", true, /\.js?$/);
 srcReq.keys().map(srcReq);
 
 // Use webpack to infer and `require` tests automatically.
-const testsReq = require.context(".", true, /\.spec.jsx?$/);
+const testsReq = require.context(".", true, /\.spec.js?$/);
 testsReq.keys().map(testsReq);
 
 // Only start mocha in browser.

--- a/test/client/spec/prop-types.spec.js
+++ b/test/client/spec/prop-types.spec.js
@@ -1,0 +1,148 @@
+import {
+  nonNegative,
+  domain,
+  scale,
+  homogeneousArray
+} from "src/prop-types";
+
+describe("prop-types", () => {
+
+  describe("nonNegative", () => {
+    const validate = function (prop) {
+      return nonNegative({testProp: prop}, "testProp", "TestComponent");
+    };
+
+    it("returns an error for non numeric values", () => {
+      const result = validate("a");
+      expect(result).to.be.an.instanceOf(Error);
+      expect(result.message).contain(
+        "`string` supplied to `TestComponent`, expected `number`."
+      );
+    });
+
+    it("returns an error for negative numeric values", () => {
+      const result = validate(-1);
+      expect(result).to.be.an.instanceOf(Error);
+      expect(result.message).to.contain(
+        "`testProp` in `TestComponent` must be non-negative."
+      );
+    });
+
+    it("does not return an error for positive numeric values", () => {
+      const result = validate(1);
+      expect(result).not.to.be.an.instanceOf(Error);
+    });
+
+    it("does not return an error for zero", () => {
+      const result = validate(0);
+      expect(result).not.to.be.an.instanceOf(Error);
+    });
+  });
+
+  describe("domain", () => {
+    const validate = function (prop) {
+      return domain({testProp: prop}, "testProp", "TestComponent");
+    };
+
+    it("returns an error for non array values", () => {
+      const result = validate("a");
+      expect(result).to.be.an.instanceOf(Error);
+      expect(result.message).contain(
+        "`string` supplied to `TestComponent`, expected `array`."
+      );
+    });
+
+    it("returns an error when the length of the array is not two", () => {
+      const result = validate([1]);
+      expect(result).to.be.an.instanceOf(Error);
+      expect(result.message).contain(
+        "`testProp` in `TestComponent` must be an array of two unique numeric values."
+      );
+    });
+
+    it("returns an error when the values of the array are equal", () => {
+      const result = validate([1, 1]);
+      expect(result).to.be.an.instanceOf(Error);
+      expect(result.message).contain(
+        "`testProp` in `TestComponent` must be an array of two unique numeric values."
+      );
+    });
+
+    it("does not return an error for two element ascending arrays", () => {
+      const result = validate([0, 1]);
+      expect(result).not.to.be.an.instanceOf(Error);
+    });
+
+    it("does not return an error for two element descending arrays", () => {
+      const result = validate([1, 0]);
+      expect(result).not.to.be.an.instanceOf(Error);
+    });
+
+    it("does not return an error arrays of dates", () => {
+      const result = validate([new Date(1980, 1, 1), new Date(1990, 1, 1)]);
+      expect(result).not.to.be.an.instanceOf(Error);
+    });
+  });
+
+  describe("scale", () => {
+    const validate = function (prop) {
+      return scale({testProp: prop}, "testProp", "TestComponent");
+    };
+
+    it("returns an error for non function values", () => {
+      const result = validate("a");
+      expect(result).to.be.an.instanceOf(Error);
+      expect(result.message).contain(
+        "`testProp` in `TestComponent` must be a d3 scale."
+      );
+    });
+
+    it("returns an error when the function does not have a domain, range, and copy methods", () => {
+      const testFunc = () => {"oops";};
+      const result = validate(testFunc);
+      expect(result).to.be.an.instanceOf(Error);
+      expect(result.message).contain(
+        "`testProp` in `TestComponent` must be a d3 scale."
+      );
+    });
+
+    it.skip("does not return an error when the function is a d3 scale", () => {
+      // const testFunc = d3.scale.linear; TODO: Mock this rather than depending on d3
+      // const result = validate(testFunc);
+      // expect(result).not.to.be.an.instanceOf(Error);
+    });
+  });
+
+  describe("homogeneousArray", () => {
+    const validate = function (prop) {
+      return homogeneousArray({testProp: prop}, "testProp", "TestComponent");
+    };
+
+    it("returns an error for non array values", () => {
+      const result = validate("a");
+      expect(result).to.be.an.instanceOf(Error);
+      expect(result.message).contain(
+        "`string` supplied to `TestComponent`, expected `array`."
+      );
+    });
+
+    it("returns an error when the array has elements of different types", () => {
+      const result = validate([1, "a"]);
+      expect(result).to.be.an.instanceOf(Error);
+      expect(result.message).contain(
+        "Expected `testProp` in `TestComponent` to be a homogeneous array, but found " +
+        "types `Number` and `String`."
+      );
+    });
+
+    it("does not return an error for empty arrays", () => {
+      const result = validate([]);
+      expect(result).not.to.be.an.instanceOf(Error);
+    });
+
+    it("does not return an error for arrays where all elements are the same type", () => {
+      const result = validate([1, 0]);
+      expect(result).not.to.be.an.instanceOf(Error);
+    });
+  });
+});


### PR DESCRIPTION
cc/ @exogen or cc /@coopy

this PR: 
changes `minMaxArray` -> `domain` and drops the requirement for an ascending array
changes the spelling on `homogeneousArray`
adds tests
