### PR TITLE
Remove invisible styles

### DIFF
--- a/src/chart.js
+++ b/src/chart.js
@@ -1,6 +1,7 @@
 import transform from "lodash/object/transform";
 import merge from "lodash/object/merge";
 import some from "lodash/collection/some";
+import * as Style from "./style";
 
 module.exports = {
   getPadding(props) {
@@ -18,9 +19,11 @@ module.exports = {
     const style = props.style || defaultStyles;
     const {data, labels, parent} = style;
     return {
-      parent: merge({}, defaultStyles.parent, parent, {height: props.height, width: props.width}),
-      labels: merge({}, defaultStyles.labels, labels),
-      data: merge({}, defaultStyles.data, data)
+      parent: Style.removeInvisible(merge(
+        {}, defaultStyles.parent, parent, {height: props.height, width: props.width}
+      )),
+      labels: Style.removeInvisible(merge({}, defaultStyles.labels, labels)),
+      data: Style.removeInvisible(merge({}, defaultStyles.data, data))
     };
   },
 

--- a/src/style.js
+++ b/src/style.js
@@ -1,5 +1,6 @@
 import reduceCSSCalc from "reduce-css-calc";
-
+import keys from "lodash/object/keys";
+import omit from "lodash/object/omit";
 /**
  * Given an object with CSS/SVG transform definitions, return the string value
  * for use with the `transform` CSS property or SVG attribute. Note that we
@@ -51,4 +52,11 @@ export const getColorScale = function (name) {
     green: ["#354722", "#466631", "#649146", "#8AB25C", "#A9C97E"]
   };
   return name ? scales[name] : scales.greyscale;
+};
+
+export const removeInvisible = function (style) {
+  const invisibleKeys = keys(style).filter((key) => {
+    return style[key] === "transparent" || style[key] === "none";
+  });
+  return omit(style, invisibleKeys);
 };

--- a/test/client/spec/chart.spec.js
+++ b/test/client/spec/chart.spec.js
@@ -40,17 +40,26 @@ describe("chart", () => {
   });
 
   describe("getStyles", () => {
-    const style = {data: {fill: "red"}, labels: {fontSize: 12}};
     const defaultStyles = {
       parent: {border: "black"},
       data: {fill: "blue", stroke: "black"},
       labels: {fontSize: 10, fontFamily: "Helvetica"}
     };
-    const props = {style, width: 500, height: 500};
     it("merges styles", () => {
+      const style = {data: {fill: "red"}, labels: {fontSize: 12}};
+      const props = {style, width: 500, height: 500};
       const styles = Chart.getStyles(props, defaultStyles);
       expect(styles.parent).to.deep.equal({border: "black", width: 500, height: 500});
       expect(styles.data).to.deep.equal({fill: "red", stroke: "black"});
+      expect(styles.labels).to.deep.equal({fontSize: 12, fontFamily: "Helvetica"});
+    });
+
+    it("does not include invisible styles", () => {
+      const style = {data: {fill: "red", stroke: "transparent"}, labels: {fontSize: 12}};
+      const props = {style, width: 500, height: 500};
+      const styles = Chart.getStyles(props, defaultStyles);
+      expect(styles.parent).to.deep.equal({border: "black", width: 500, height: 500});
+      expect(styles.data).to.deep.equal({fill: "red"});
       expect(styles.labels).to.deep.equal({fontSize: 12, fontFamily: "Helvetica"});
     });
   });


### PR DESCRIPTION
cc/ @coopy this PR removes invisible styles (_i.e._ "transparent") that are not correctly handled in `art` / `react-art`
