### PR TITLE
Perf optimizations

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -24,7 +24,7 @@ module.exports = {
     };
   },
 
-  getStyles(style, defaultStyles, height, width) {
+  getStyles(style, defaultStyles, height, width) { // eslint-disable-line max-params
     if (!style) {
       return merge({}, defaultStyles, { parent: { height, width } });
     }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -24,11 +24,14 @@ module.exports = {
     };
   },
 
-  getStyles(props, defaultStyles) {
-    const style = props.style || defaultStyles;
+  getStyles(style, defaultStyles, height, width) {
+    if (!style) {
+      return merge({}, defaultStyles, { parent: { height, width } });
+    }
+
     const {data, labels, parent} = style;
     return {
-      parent: merge({}, defaultStyles.parent, parent, {height: props.height, width: props.width}),
+      parent: merge({}, defaultStyles.parent, parent, { height, width }),
       labels: merge({}, defaultStyles.labels, labels),
       data: merge({}, defaultStyles.data, data)
     };

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import * as Log from "./log";
 import * as Style from "./style";
 import * as Type from "./type";
 import * as PropTypes from "./prop-types";
+import * as Perf from "./perf";
 
 export default {
   Collection,
@@ -11,5 +12,6 @@ export default {
   Log,
   Style,
   Type,
-  PropTypes
+  PropTypes,
+  Perf
 };

--- a/src/perf.js
+++ b/src/perf.js
@@ -1,12 +1,12 @@
-export function memoize (fn) {
+export const memoize = function (fn) {
   const cache = {};
   return function () {
     const args = Array.prototype.slice.call(arguments);
-    const hash = args.map(arg => {
+    const hash = args.map((arg) => {
       return (typeof arg === "string" || typeof arg === "number") ? arg : JSON.stringify(arg);
     }).join("~");
     return hash in cache ?
       cache[hash] :
-      cache[hash] = fn.apply(this, args);
+      cache[hash] = fn.apply(this, args); // eslint-disable-line no-invalid-this
   };
-}
+};

--- a/src/perf.js
+++ b/src/perf.js
@@ -1,0 +1,12 @@
+export function memoize (fn) {
+  const cache = {};
+  return function () {
+    const args = Array.prototype.slice.call(arguments);
+    const hash = args.map(arg => {
+      return (typeof arg === "string" || typeof arg === "number") ? arg : JSON.stringify(arg);
+    }).join("~");
+    return hash in cache ?
+      cache[hash] :
+      cache[hash] = fn.apply(this, args);
+  };
+}

--- a/test/client/spec/helpers.spec.js
+++ b/test/client/spec/helpers.spec.js
@@ -50,8 +50,9 @@ describe("helpers", () => {
     };
     it("merges styles", () => {
       const style = {data: {fill: "red"}, labels: {fontSize: 12}};
-      const props = {style, width: 500, height: 500};
-      const styles = Helpers.getStyles(props, defaultStyles);
+      const width = 500;
+      const height = 500;
+      const styles = Helpers.getStyles(style, defaultStyles, height, width);
       expect(styles.parent).to.deep.equal({border: "black", width: 500, height: 500});
       expect(styles.data).to.deep.equal({fill: "red", stroke: "black"});
       expect(styles.labels).to.deep.equal({fontSize: 12, fontFamily: "Helvetica"});


### PR DESCRIPTION
This PR is in support of https://github.com/FormidableLabs/victory-chart/pull/93.  It include one hot-path performance improvement, as well as a multi-arg memoization function that is consumed by `victory-chart`.

It looks like I have to update a couple of tests for `getStyles`.  Also, this PR will probably have to wait until after the `victory-core` merge.

/cc @boygirl @coopy 
