### PR TITLE
Added deprecated propType

### DIFF
--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -1,9 +1,34 @@
+/* global console */
 import bind from "lodash/function/bind";
 import includes from "lodash/collection/includes";
 import isFunction from "lodash/lang/isFunction";
 
 import { PropTypes } from "react";
 import { getConstructor, getConstructorName } from "./type";
+
+/**
+ * Return a new validator based on `propType` but which logs a `console.error`
+ * with `explanation` if used.
+ * @param {Function} propType The old, deprecated propType.
+ * @param {String} explanation The message to provide the user of the deprecated propType.
+ * @returns {Function} Validator which logs usage of this propType
+ */
+export const deprecated = (propType, explanation) => {
+  return (props, propName, componentName) => {
+    if (process.env.NODE_ENV !== "production") {
+      /* eslint-disable no-console */
+      if (typeof console !== "undefined" && console.error) {
+        if (props[propName] !== null) {
+          console.error(false,
+            `"${propName}" property of "${componentName}" has been deprecated ${explanation}`);
+        }
+      }
+      /* eslint-enable no-console */
+    }
+
+    return propType(props, propName, componentName);
+  };
+};
 
 /**
  * Return a new validator based on `validator` but with the option to chain

--- a/test/client/spec/prop-types.spec.js
+++ b/test/client/spec/prop-types.spec.js
@@ -1,13 +1,62 @@
+/* global sinon */
+/* global console */
+import {PropTypes} from "react";
 import {
   allOfType,
   nonNegative,
   integer,
   domain,
   scale,
-  homogeneousArray
+  homogeneousArray,
+  deprecated
 } from "src/prop-types";
 
 describe("prop-types", () => {
+
+  /* eslint-disable no-console */
+  // Directly lifted from https://github.com/react-bootstrap/react-prop-types
+  // And then adapted to work with our linter, and sinon sandbox
+  describe("deprecated", () => {
+    let sandbox;
+
+    const shouldError = () => {
+      sinon.assert.calledOnce(console.error);
+    };
+
+    const validate = (prop) => {
+      return deprecated(PropTypes.string, "Read more at link")({
+        pName: prop
+      }, "pName", "ComponentName");
+    };
+
+    beforeEach(() => {
+      sandbox = sinon.sandbox.create();
+      sandbox.stub(console, "error");
+    });
+
+    afterEach(() => {
+      console.error.restore();
+      sandbox.reset();
+    });
+
+    it("Should warn about deprecation and validate OK", () => {
+
+      const err = validate("value");
+      shouldError("`pName` property of `ComponentName1 has been deprecated.\nRead more at link");
+      expect(err).to.not.be.an.instanceOf(Error);
+    });
+
+    it(`Should warn about deprecation and throw validation error when property
+       value is not OK`, () => {
+
+      const err = validate({});
+      shouldError("`pName` property of `ComponentName` has been deprecated.\nRead more at link");
+      expect(err).to.be.an.instanceOf(Error);
+      expect(err.message).to.include(
+        "Invalid undefined `pName` of type `object` supplied to `ComponentName`");
+    });
+  });
+  /* eslint-enable no-console */
 
   describe("allOfType", () => {
     const validate = function (prop) {


### PR DESCRIPTION
In https://github.com/FormidableLabs/victory-chart/issues/96 I am proposing changes to the `propType` interface of `VictoryBar`. I do not have data to support this decision. Therefore, I would like to add deprecation notices so that users of the old `propType` API of `VictoryBar` have a chance to adapt.

I wasn't sure about adding a dependency to https://github.com/react-bootstrap/react-prop-types for just this one `propType` especially as you have some of your own with similar functionality but slightly different naming. I've watched https://github.com/react-bootstrap/react-prop-types so that if any bugs are filed on `deprecated` I can see that and respond here.
